### PR TITLE
Fixing Seals id to be unique per possible user.

### DIFF
--- a/bin/iceberg
+++ b/bin/iceberg
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     print parsed_values
     if parsed_values['analysis']['which'] == 'seals':
         exec_obj = Seals(name=ru.generate_id('seals.%(item_counter)04d',
-                         mode=ru.ID_CUSTOM, namespace='seals'),
+                         mode=ru.ID_PRIVATE, namespace='seals'),
                          resources={
                             'resource': parsed_values['general']['resource'],
                             'queue': parsed_values['general']['queue'],


### PR DESCRIPTION
This fixes #19.

Sessions id were: `'seals.0000'` and the suffix was increasing by one per run. Now session ids are: `seals.iparaskmac.iparask.018218.0000`. This makes sure that not one user will have the same session name. 