### PR TITLE
Adding endpoints as part of the config file and parameters

### DIFF
--- a/bin/iceberg
+++ b/bin/iceberg
@@ -13,10 +13,30 @@ from iceberg.executor import Seals
 if __name__ == "__main__":
 
     parsed_values = IcebergParser().args()
-    print parsed_values
+    import os
+
+    if ['rmq_endpoint'] in parsed_values:
+        os.environ['RMQ_ENDPOINT'] = parsed_values['rmq_endpoint']
+    elif 'RMQ_ENDPOINT' not in os.environ:
+        raise RuntimeError('RMQ_ENDPOINT is not setup.')
+    
+    if ['rmq_port'] in parsed_values:
+        os.environ['RMQ_PORT'] = parsed_values['rmq_port']
+    elif 'RMQ_PORT' not in os.environ:
+        raise RuntimeError('RMQ_PORT is not setup.')
+    
+    if ['radical_pilot_dburl'] in parsed_values:
+        os.environ['RADICAL_PILOT_DBURL'] = parsed_values['radical_pilot_dburl']
+    elif 'RADICAL_PILOT_DBURL' not in os.environ:
+        raise RuntimeError('RADICAL_PILOT_DBURL is not setup.')
+    
     if parsed_values['analysis']['which'] == 'seals':
+        if ['ve_seals'] in parsed_values:
+            os.environ['VE_SEALS'] = parsed_values['ve_seal']
+        elif 'VE_SEALS' not in os.environ:
+            raise RuntimeError('VE_SEALS is not setup.')
         exec_obj = Seals(name=ru.generate_id('seals.%(item_counter)04d',
-                         mode=ru.ID_PRIVATE, namespace='seals'),
+                         mode=ru.ID_CUSTOM, namespace='seals'),
                          resources={
                             'resource': parsed_values['general']['resource'],
                             'queue': parsed_values['general']['queue'],

--- a/src/iceberg/iceberg_parser/iceberg_parser.py
+++ b/src/iceberg/iceberg_parser/iceberg_parser.py
@@ -72,13 +72,17 @@ class IcebergParser(object):
                                        help='The project ID to charge',
                                        type=str, default=None)
             required_args.add_argument('--rmq_endpoint',
-                                       help='The project ID to charge',
+                                       help='RMQ endpoint for EnTK. \
+                                             This is a url.',
                                        type=str, default=None)
             required_args.add_argument('--rmq_port',
-                                       help='The project ID to charge',
+                                       help='RMQ port. This is the port \
+                                       number RMQ listens to.',
                                        type=str, default=None)
-            required_args.add_argument('--radical_pilot_dburl', '-pr',
-                                       help='The project ID to charge',
+            required_args.add_argument('--radical_pilot_dburl', '-rpdb',
+                                       help='RD MongoDB URL. \
+                                       This URL has the following form: \
+                                       mongodb://<uname>:<password>@ip:port/db_name',
                                        type=str, default=None)
 
             command_parser = parser.add_subparsers(help='commands')

--- a/src/iceberg/iceberg_parser/iceberg_parser.py
+++ b/src/iceberg/iceberg_parser/iceberg_parser.py
@@ -71,9 +71,18 @@ class IcebergParser(object):
             required_args.add_argument('--project', '-pr',
                                        help='The project ID to charge',
                                        type=str, default=None)
+            required_args.add_argument('--rmq_endpoint',
+                                       help='The project ID to charge',
+                                       type=str, default=None)
+            required_args.add_argument('--rmq_port',
+                                       help='The project ID to charge',
+                                       type=str, default=None)
+            required_args.add_argument('--radical_pilot_dburl', '-pr',
+                                       help='The project ID to charge',
+                                       type=str, default=None)
 
             command_parser = parser.add_subparsers(help='commands')
-            
+
             for key, parser_impl in PARSERS.iteritems():
                 parser_impl(command_parser)
 

--- a/src/iceberg/iceberg_parser/seals_parser.py
+++ b/src/iceberg/iceberg_parser/seals_parser.py
@@ -24,4 +24,7 @@ class SealsSubparser(object):
                                       help='Model Architecture')
             seals_parser.add_argument('--hyperparameters', '-hy',
                                       help='Hyperparameter Set')
+            seals_parser.add_argument('--ve_seals',
+                                      help='Path of a python virtualenv with \
+                                      the seals package installed ')
 


### PR DESCRIPTION
I added the RMQ endpoint and port, RP db url and VE seals path as parameters in the input as well as part of the config file. If values are specified in the config file or as input parameters, then those are used. Otherwise, we check if they are part of the environment variables. If they are not a runtime error is raised notifying the user to include them.