### PR TITLE
Fixing issue #27

### DIFF
--- a/bin/iceberg
+++ b/bin/iceberg
@@ -13,10 +13,10 @@ from iceberg.executor import Seals
 if __name__ == "__main__":
 
     parsed_values = IcebergParser().args()
-    print parsed_values
+    print(parsed_values)
     if parsed_values['analysis']['which'] == 'seals':
-        exec_obj = Seals(name=ru.generate_id('seals.%(item_counter)04d',
-                         mode=ru.ID_PRIVATE, namespace='seals'),
+        exec_obj = Seals(name=ru.generate_id('seals.%(counter)04d',
+                         mode=ru.ID_CUSTOM, namespace='seals'),
                          resources={
                             'resource': parsed_values['general']['resource'],
                             'queue': parsed_values['general']['queue'],


### PR DESCRIPTION
As per `radical.utils` `generate_id` counters are allowed in `ru._ID_CUSTOM`:

```
    Example::

        sid  = generate_id('re.session', ID_PRIVATE)
        uid1 = generate_id('task.%(item_counter)04d', ID_CUSTOM, ns=sid)
        uid2 = generate_id('task.%(item_counter)04d', ID_CUSTOM, ns=sid)
        ...
```

The seals counter is updated according to the example offered bu `RADICAL.Utils`
